### PR TITLE
Auto run "CREATE TABLE" for :memory: database on sqlite3

### DIFF
--- a/storage/sqlite3/sqlite3.go
+++ b/storage/sqlite3/sqlite3.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	saveJobSQL = "INSERT INTO job(Handle,Id,Priority,CreateAt,FuncName,Data) VALUES(?,?,?,?,?,?)"
-	getJobsSQL = "SELECT * FROM job" //need to get all jobs
-	delJobSQL  = "DELETE FROM job WHERE Handle=?"
+	createTableSQL = "CREATE TABLE IF NOT EXISTS job(Handle varchar(128),Id varchar(128),Priority INT, CreateAt TIMESTAMP,FuncName varchar(128),Data varchar(16384))"
+	saveJobSQL     = "INSERT INTO job(Handle,Id,Priority,CreateAt,FuncName,Data) VALUES(?,?,?,?,?,?)"
+	getJobsSQL     = "SELECT * FROM job" //need to get all jobs
+	delJobSQL      = "DELETE FROM job WHERE Handle=?"
 )
 
 var (
@@ -30,6 +31,12 @@ func (self *SQLite3Storage) Init() error {
 	if err != nil {
 		log.Error(err)
 		return err
+	}
+
+	_, create_err := self.db.Exec(createTableSQL)
+	if create_err != nil {
+		log.Error(create_err)
+		return create_err
 	}
 
 	return self.db.Ping()


### PR DESCRIPTION
This is useful to run `:memory:` database on sqlite3.

This is also based on @kazeburo's [patch](https://gist.github.com/kazeburo/d9f2e5d9dfe93798aa84).
